### PR TITLE
fixed day of month setting in src/datetime.rs and test-case

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -165,7 +165,7 @@ where
     ///
     /// Will return an `Error::InvalidInputData` if the day is out of range.
     pub fn set_day(&mut self, day: u8) -> Result<(), Error<E>> {
-        if day < 1 || day > 7 {
+        if day < 1 || day > 31 {
             return Err(Error::InvalidInputData);
         }
         self.write_register(Register::DOM, day)

--- a/tests/day_of_month.rs
+++ b/tests/day_of_month.rs
@@ -21,7 +21,7 @@ fn too_small_day_of_month_returns_error() {
 #[test]
 fn too_big_day_of_month_returns_error() {
     let mut rtc = setup(&[0]);
-    assert_invalid_input_data_error(rtc.set_day(8));
+    assert_invalid_input_data_error(rtc.set_day(32));
 }
 
 #[test]


### PR DESCRIPTION
The set_day method was failed when valid day of month ([1-31]) was used, so fixed invalid range for day of month and the unit test.